### PR TITLE
Add Phase 1-2 draft assistant: VOR scorer and Monte Carlo lookahead

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Copy this file to `.env` and fill in your values. `.env` is gitignored.
+
+# Required for any league (public or private).
+LEAGUE_ID=
+# A season with a COMPLETED draft is best for validating right now (off-season).
+SEASON=2024
+
+# Required ONLY for private leagues. Grab these two cookies from your browser
+# while logged into fantasy.espn.com — see spike/README.md for how.
+# SWID must include the surrounding braces, e.g. {AAAAAAAA-BBBB-....}
+ESPN_S2=
+SWID=

--- a/docs/DRAFT_MODEL.md
+++ b/docs/DRAFT_MODEL.md
@@ -76,6 +76,12 @@ the prompt" approach, and it grounds the LLM in real numbers.
 
 ## Phase 2 (the real brain): Monte Carlo lookahead
 
+**Implemented:** `draft/lineup.py` (the TeamValue objective), `draft/simulate.py`
+(DraftState, snake order, ADP-noise opponent model, rollout policies,
+`mc_recommend`, survival probabilities), `draft/demo_mc.py` (side-by-side
+greedy-vs-lookahead demo; ~150 sims/candidate runs in a few seconds, well
+inside a pick clock).
+
 Replace the `need_multiplier` heuristic with the genuine article: simulate the
 rest of the draft and measure each candidate's *actual* effect on final
 `TeamValue`.

--- a/docs/DRAFT_MODEL.md
+++ b/docs/DRAFT_MODEL.md
@@ -1,0 +1,139 @@
+# Draft Model — Design
+
+How the drafting assistant decides who to recommend. This is the "brain" that
+sits behind the "press go" loop; the ESPN JSON API (see `spike/`) feeds it live
+state, and the LLM sits on top to explain picks and absorb natural-language
+preferences.
+
+## The one idea that shapes everything
+
+Separate the two problems. Fusing them is the classic mistake.
+
+1. **Player value** — how many points will a player score? Regression, lots of
+   clean data, and where real projections (ESPN/FantasyPros) or a tree model
+   live. In v1 we just *consume* projections; we don't try to beat them.
+2. **Pick strategy** — given values + scarcity + roster construction + how
+   opponents behave, which pick maximizes my *final team's* value across the
+   whole draft? Sequential, adversarial. This is the interesting part.
+
+A single model that "predicts the next best pick" from historical drafts fails
+at #2, because historical picks are just Average Draft Position (a model of the
+*average drafter*, not of *optimal play*), and "which team won" is buried under
+in-season variance (injuries, waivers, luck). So we use past-draft data as an
+**opponent-behavior model**, never as optimality labels.
+
+## Objective function
+
+We optimize **expected season-long starting-lineup points, valued over
+replacement**, at the end of the draft — not raw points, and not the value of
+the players sitting on the bench.
+
+```
+TeamValue(roster) = Σ_{starting slots s}  proj_points( best_unused_player_for(s) )
+                    − bye_conflict_penalty(roster)
+```
+
+The draft goal is to choose picks that maximize expected final `TeamValue`.
+Everything the user asked for — scarcity, positional runs, not stacking byes,
+roster balance — is a *consequence* of this objective, not a hand-coded rule.
+
+## Phase 1 (shipping now): need-aware VOR, greedy
+
+A fast, deterministic, fully interpretable score for each available player.
+This is what `draft/scorer.py` implements today.
+
+**Value Over Replacement (VOR / VBD):**
+
+```
+VOR(p) = proj_points(p) − replacement_points(pos(p))
+```
+
+`replacement_points(pos)` = the projection of the *last startable* player at
+that position across the whole league, i.e. roughly the
+`(n_teams × starters_per_team_at_pos)`-th best player at that position (flex
+folded in). This is why an elite RB outscores an elite QB in VOR even though the
+QB scores more raw points — QB replacement level is nearly as high as QB1.
+
+**Need-aware adjustment** (a cheap stand-in for "what does this actually add to
+my starting lineup?"):
+
+```
+score(p | roster) = VOR(p) × need_multiplier(pos, roster) − bye_penalty(p, roster)
+```
+
+- `need_multiplier` ≈ 1.0 if `p` fills an open starting slot, ~0.9 for flex,
+  and a discount if the position's starting slots are already full (bench /
+  injury insurance only).
+- `bye_penalty` grows when `p` shares a bye week with players already
+  penciled into my starting lineup — heavily for the same position.
+
+We also surface a **tier-cliff** signal (how many players remain in `p`'s tier
+at its position) so the assistant can say "grab RB now, the tier falls off a
+cliff before your next pick."
+
+Greedy VOR is already dramatically better than the old "dump every ranking into
+the prompt" approach, and it grounds the LLM in real numbers.
+
+## Phase 2 (the real brain): Monte Carlo lookahead
+
+Replace the `need_multiplier` heuristic with the genuine article: simulate the
+rest of the draft and measure each candidate's *actual* effect on final
+`TeamValue`.
+
+```
+for each candidate pick p at the current state:
+    for i in 1..N simulations:
+        take p, then play the draft to completion:
+            - opponents pick by sampling ADP (with noise)      # opponent model
+            - I fill my remaining picks with a fast rollout heuristic (Phase-1 VOR)
+        record final TeamValue_i
+    E[value | p] = mean(TeamValue_i)
+recommend argmax_p E[value | p]
+```
+
+Why Monte Carlo, not RL, as the core engine:
+
+- The **opponent model is nearly free**: real ESPN leagues (humans + auto-pick)
+  draft close to ADP, so sampling ADP with noise is a genuinely good simulator.
+- Scarcity, positional runs, bye balance, and roster construction all **emerge**
+  from simulating to the end — no rules to maintain.
+- **Off-path replanning is free**: we re-solve from the actual board every pick,
+  so "someone drafted off the predicted path" just means we recompute. There is
+  no fragile predicted path to break.
+- With ~15 rounds and a 30–90s pick clock, inference-time simulation is fast
+  enough. RL's payoff (amortize planning into one forward pass) isn't needed.
+
+## Where trees and RL fit (later, optional)
+
+- **Value tree (regression):** blend projection sources / build our own edge.
+  Optional — expert projections are hard to beat.
+- **Opponent tree (classification):** `P(player picked within next k picks |
+  ADP, round, position-run state, …)`. This is the *correct* home for
+  "learn from past drafts" — a well-posed problem with real labels (we observe
+  who got picked) that sharpens the simulator's opponents.
+- **Learned / RL policy:** distilled from the simulator, only if we want instant
+  inference or want to *discover* non-obvious strategy (e.g. does Zero-RB beat
+  balanced in our specific league settings?). We need the simulator either way,
+  so it comes first.
+
+## The LLM's job
+
+The planner emits numbers and a ranked shortlist. The LLM (provider-swappable)
+(1) explains the recommendation in plain language and (2) lets the user inject
+soft preferences mid-draft ("go Zero-RB", "avoid anyone on the Jets", "I have
+too many Week 9 byes") that reweight the objective. It does judgment and
+communication; it does not do the arithmetic.
+
+## Data sources
+
+| Need                | Real pipeline (ESPN)                  | Offline prototype              |
+| ------------------- | ------------------------------------- | ------------------------------ |
+| Projected points    | `kona_player_info` view               | proxy from positional rank *   |
+| Bye weeks           | player metadata / rankings            | FantasyPros CSV `BYE WEEK`     |
+| Live board / picks  | `mDraftDetail` (polled)               | simulated mid-draft state      |
+| ADP (opponent model)| `kona_player_info` draftRanks         | FantasyPros `RK` as ADP proxy  |
+| League settings     | `mSettings`                           | hardcoded (10-team PPR)        |
+
+\* The proxy is a transparent per-position decay curve in `draft/value.py`
+(`PROJECTION_ANCHORS`). Replace `proj_points_from_rank` with real projections
+and every downstream number becomes real — nothing else changes.

--- a/draft/__init__.py
+++ b/draft/__init__.py
@@ -1,0 +1,1 @@
+"""Draft assistant: value model and pick recommender (Phase 1)."""

--- a/draft/demo.py
+++ b/draft/demo.py
@@ -1,0 +1,67 @@
+"""Run the Phase 1 recommender on real player data with a simulated draft state.
+
+    python -m draft.demo
+
+Loads the FantasyPros universe, marks the top overall players as already
+drafted by opponents, assigns us a plausible mid-draft roster, and prints the
+ranked recommendation for our next pick — with the reasoning behind each.
+"""
+
+from .league import LeagueConfig
+from .players import load_players
+from .scorer import recommend
+
+CSV = "Expert_Picks/FantasyPros_2024_Draft_ALL_Rankings.csv"
+
+# A plausible mid-draft roster to make the decision interesting: we're WR/QB/TE
+# heavy and have zero RBs, so RB need should dominate. Names exist in the 2024
+# file. (Live pipeline identifies our roster by ESPN player ID, no name matching.)
+MY_ROSTER_NAMES = ["CeeDee Lamb", "Josh Allen", "Mark Andrews"]
+
+
+def _find(players, name):
+    for p in players:
+        if p.name.lower() == name.lower():
+            return p
+    raise SystemExit(f"'{name}' not found in {CSV}; adjust MY_ROSTER_NAMES.")
+
+
+def main():
+    config = LeagueConfig()
+    universe = load_players(CSV)
+
+    roster = [_find(universe, n) for n in MY_ROSTER_NAMES]
+    roster_names = {p.name for p in roster}
+
+    # Simulate opponents having taken the best remaining players: mark the top
+    # ~40 overall (that aren't ours) as gone, so we're picking around round 5.
+    drafted = set(roster_names)
+    for p in universe:
+        if len(drafted) >= 40:
+            break
+        drafted.add(p.name)
+    available = [p for p in universe if p.name not in drafted]
+
+    print(f"League: {config.n_teams}-team {config.scoring}")
+    print("My roster:", ", ".join(f"{p.name} ({p.pos})" for p in roster))
+    byes = ", ".join(f"{p.pos} {p.name} bye {p.bye}" for p in roster)
+    print("Byes:    ", byes)
+    print(f"\nTop available: {available[0].name}, {available[1].name}, "
+          f"{available[2].name} ...\n")
+
+    print("=" * 78)
+    print("RECOMMENDED PICKS (score = VOR x need - bye penalty)")
+    print("=" * 78)
+    for i, r in enumerate(recommend(available, roster, config, top_k=8), 1):
+        p = r.player
+        print(f"{i}. {p.name:<22} {p.pos}{p.pos_rank:<3} "
+              f"score {r.score:6.1f}  (VOR {r.base_vor:5.1f} x "
+              f"need {r.need_multiplier:.2f})")
+        print(f"     -> {'; '.join(r.reasons)}")
+    print("=" * 78)
+    print("Note: projected points are a rank-derived PROXY offline; the live "
+          "pipeline\nswaps in real ESPN projections via value.proj_points.")
+
+
+if __name__ == "__main__":
+    main()

--- a/draft/demo_mc.py
+++ b/draft/demo_mc.py
@@ -1,0 +1,122 @@
+"""Phase 2 demo: Monte Carlo lookahead vs Phase-1 greedy on the same board.
+
+    python -m draft.demo_mc [n_sims]
+
+Rebuilds the Phase-1 demo state (10-team PPR, ~round 5, we have zero RBs) and
+shows how simulating the rest of the draft changes the recommendation —
+including P(player survives to your next pick) for every candidate.
+"""
+
+import sys
+import time
+
+from .league import LeagueConfig
+from .lineup import best_lineup, lineup_value
+from .players import load_players
+from .scorer import recommend
+from .simulate import DraftState, mc_recommend, play_out, team_for_pick
+import random
+
+CSV = "Expert_Picks/FantasyPros_2024_Draft_ALL_Rankings.csv"
+
+# Same interesting state as draft/demo.py: WR/QB/TE filled, zero RBs.
+MY_ROSTER_NAMES = ["CeeDee Lamb", "Josh Allen", "Mark Andrews", "Drake London"]
+MY_TEAM = 0
+PICKS_MADE = 40  # 10 teams x 4 rounds done; pick 41 (ours) is on the clock
+
+
+def build_state():
+    config = LeagueConfig()
+    universe = load_players(CSV)
+    by_name = {p.name: p for p in universe}
+
+    missing = [n for n in MY_ROSTER_NAMES if n not in by_name]
+    if missing:
+        raise SystemExit(f"Not in {CSV}: {missing}")
+    mine = [by_name[n] for n in MY_ROSTER_NAMES]
+    taken = {p.name for p in mine}
+
+    # Opponents drafted the best of the rest: top 36 by ADP, dealt round-robin.
+    rosters = [[] for _ in range(config.n_teams)]
+    rosters[MY_TEAM] = list(mine)
+    opp_teams = [t for t in range(config.n_teams) if t != MY_TEAM]
+    i = 0
+    for p in universe:
+        if len(taken) >= PICKS_MADE:
+            break
+        if p.name in taken:
+            continue
+        rosters[opp_teams[i % len(opp_teams)]].append(p)
+        taken.add(p.name)
+        i += 1
+
+    available = [p for p in universe if p.name not in taken]
+    state = DraftState(config, available, rosters, next_pick=PICKS_MADE)
+    assert team_for_pick(state.next_pick, config.n_teams) == MY_TEAM
+    return state
+
+
+def main():
+    n_sims = int(sys.argv[1]) if len(sys.argv) > 1 else 100
+    state = build_state()
+    config = state.config
+    roster = state.rosters[MY_TEAM]
+
+    rnd = state.next_pick // config.n_teams + 1
+    print(f"League: {config.n_teams}-team {config.scoring} | "
+          f"Round {rnd}, overall pick {state.next_pick + 1} (you)")
+    print("Your roster:", ", ".join(f"{p.name} ({p.pos})" for p in roster))
+
+    greedy = recommend(state.available, roster, config, top_k=5)
+    print("\nPhase 1 (greedy VOR) top 5:")
+    for i, r in enumerate(greedy, 1):
+        print(f"  {i}. {r.player.name:<22} {r.player.pos}{r.player.pos_rank:<3}"
+              f" score {r.score:5.1f}")
+
+    t0 = time.perf_counter()
+    evals = mc_recommend(state, MY_TEAM, n_sims=n_sims, seed=42)
+    dt = time.perf_counter() - t0
+
+    print(f"\nPhase 2 (Monte Carlo lookahead, {n_sims} sims/candidate, "
+          f"{dt:.1f}s):")
+    print(f"{'':3}{'player':<22}{'pos':<6}{'E[team value]':>14}"
+          f"{'  ±SE':>7}{'  survives to next pick':>24}")
+    for i, e in enumerate(evals, 1):
+        p = e.player
+        print(f"{i:>2}. {p.name:<22}{p.pos}{p.pos_rank:<4}"
+              f"{e.mean_value:>12.1f}{e.std_err:>7.2f}"
+              f"{e.survival_pct:>18.0f}%")
+
+    g1, m1 = greedy[0].player, evals[0].player
+    print()
+    if g1.name == m1.name:
+        print(f"Greedy and lookahead agree: {m1.name}.")
+    else:
+        gname = g1.name
+        g_in_mc = next((e for e in evals if e.player.name == gname), None)
+        print(f"Lookahead OVERRULES greedy: {m1.name} over {gname}.")
+        if g_in_mc:
+            print(f"  {gname}: E[team] {g_in_mc.mean_value:.1f} vs "
+                  f"{evals[0].mean_value:.1f}, and survives to your next "
+                  f"pick in {g_in_mc.survival_pct:.0f}% of sims "
+                  f"(vs {evals[0].survival_pct:.0f}% for {m1.name}).")
+
+    # Show one representative completed draft for trust in the rollouts.
+    sim = state.clone()
+    idx = next(i for i, p in enumerate(sim.available)
+               if p.name == evals[0].player.name)
+    sim.rosters[MY_TEAM].append(sim.available.pop(idx))
+    sim.next_pick += 1
+    play_out(sim, MY_TEAM, random.Random(7))
+    final = sim.rosters[MY_TEAM]
+    starters = best_lineup(final, config)
+    starter_ids = {id(p) for p in starters}
+    print(f"\nOne simulated end-state roster (TeamValue "
+          f"{lineup_value(final, config):.1f}):")
+    print("  starters:", ", ".join(f"{p.name} ({p.pos})" for p in starters))
+    print("  bench:   ", ", ".join(p.name for p in final
+                                   if id(p) not in starter_ids))
+
+
+if __name__ == "__main__":
+    main()

--- a/draft/league.py
+++ b/draft/league.py
@@ -1,0 +1,51 @@
+"""League configuration: size, starting lineup, flex eligibility.
+
+Defaults match the user's league (10-team PPR) per the original notebook and
+Current_Roster.csv. In the real pipeline these come from the ESPN `mSettings`
+view instead of being hardcoded.
+"""
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class LeagueConfig:
+    n_teams: int = 10
+    scoring: str = "PPR"
+    # Starting-lineup slots (excludes bench). FLEX handled separately.
+    starters: dict = field(
+        default_factory=lambda: {
+            "QB": 1,
+            "RB": 2,
+            "WR": 2,
+            "TE": 1,
+            "FLEX": 1,
+            "D/ST": 1,
+            "K": 1,
+        }
+    )
+    flex_positions: tuple = ("RB", "WR", "TE")
+
+    def dedicated_starters(self, pos: str) -> int:
+        """Starting slots reserved for `pos`, ignoring flex."""
+        return self.starters.get(pos, 0)
+
+    def flex_share(self, pos: str) -> float:
+        """Fraction of the league's flex slots that tend to go to `pos`.
+
+        Split flex evenly across flex-eligible positions as a first
+        approximation; used only to place the replacement baseline.
+        """
+        if pos not in self.flex_positions:
+            return 0.0
+        return 1.0 / len(self.flex_positions)
+
+    def replacement_rank(self, pos: str) -> int:
+        """Positional rank of the last 'startable' player leaguewide.
+
+        e.g. 10 teams x 2 starting RB + flex share -> ~RB25 is replacement.
+        """
+        flex_slots = self.starters.get("FLEX", 0)
+        starters_at_pos = self.dedicated_starters(pos) + self.flex_share(pos) * flex_slots
+        rank = round(self.n_teams * starters_at_pos)
+        return max(rank, 1)

--- a/draft/lineup.py
+++ b/draft/lineup.py
@@ -1,0 +1,57 @@
+"""The draft objective: value of a finished roster's best starting lineup.
+
+This is what the Monte Carlo lookahead maximizes (docs/DRAFT_MODEL.md):
+
+    TeamValue(roster) = sum of proj_points over the best legal starting lineup
+                        - bye-congestion penalty among those starters
+
+Bench players contribute nothing directly — their value shows up only by
+upgrading a starter. Unfilled starting slots contribute 0 points, so rollout
+policies are naturally pressured to complete a legal lineup (QB/DST/K included).
+"""
+
+from .league import LeagueConfig
+from .scorer import BYE_OTHER_POS, BYE_SAME_POS
+
+
+def best_lineup(roster, config: LeagueConfig) -> list:
+    """Pick the best legal starting lineup from a roster.
+
+    Dedicated slots take the top players at their position; FLEX then takes
+    the best remaining flex-eligible player. Greedy is optimal here because
+    dedicated slots and FLEX want players in the same descending order.
+    """
+    by_pos = {}
+    for p in roster:
+        by_pos.setdefault(p.pos, []).append(p)
+    for lst in by_pos.values():
+        lst.sort(key=lambda p: p.proj_points, reverse=True)
+
+    starters, used = [], set()
+    for pos, count in config.starters.items():
+        if pos == "FLEX":
+            continue
+        for p in by_pos.get(pos, [])[:count]:
+            starters.append(p)
+            used.add(id(p))
+
+    flex_pool = [
+        p
+        for pos in config.flex_positions
+        for p in by_pos.get(pos, [])
+        if id(p) not in used
+    ]
+    flex_pool.sort(key=lambda p: p.proj_points, reverse=True)
+    starters.extend(flex_pool[: config.starters.get("FLEX", 0)])
+    return starters
+
+
+def lineup_value(roster, config: LeagueConfig) -> float:
+    """TeamValue: starting-lineup points minus bye congestion among starters."""
+    starters = best_lineup(roster, config)
+    value = sum(p.proj_points for p in starters)
+    for i, a in enumerate(starters):
+        for b in starters[i + 1 :]:
+            if a.bye and a.bye == b.bye:
+                value -= BYE_SAME_POS if a.pos == b.pos else BYE_OTHER_POS
+    return value

--- a/draft/players.py
+++ b/draft/players.py
@@ -1,0 +1,72 @@
+"""Load the player universe from the FantasyPros rankings CSV.
+
+Gives us real names, positions, positional ranks, tiers, and bye weeks. The
+projected-points field is filled by the value-model proxy (see value.py).
+"""
+
+import csv
+import re
+from dataclasses import dataclass
+
+from .value import proj_points_from_rank
+
+_POS_RE = re.compile(r"([A-Za-z/]+?)(\d+)?$")
+
+
+@dataclass
+class Player:
+    name: str
+    pos: str            # RB, WR, QB, TE, D/ST, K
+    pos_rank: int       # 1-based rank within position (from "RB1" etc.)
+    overall_rank: int   # overall board rank (doubles as ADP proxy)
+    tier: int
+    bye: int
+    proj_points: float  # per-game; proxy offline, real ESPN projection live
+
+    def __repr__(self):
+        return f"{self.name} ({self.pos}{self.pos_rank}, bye {self.bye})"
+
+
+def _parse_pos(raw: str):
+    """'RB1' -> ('RB', 1); 'D/ST' -> ('D/ST', None)."""
+    raw = raw.strip()
+    m = _POS_RE.match(raw)
+    if not m:
+        return raw, None
+    pos, rank = m.group(1), m.group(2)
+    return pos, (int(rank) if rank else None)
+
+
+def _to_int(value, default=0):
+    try:
+        return int(str(value).strip())
+    except (ValueError, TypeError):
+        return default
+
+
+def load_players(csv_path: str) -> list:
+    """Parse the FantasyPros CSV into Player objects, ordered by board rank."""
+    players = []
+    pos_counters = {}
+    with open(csv_path, newline="") as f:
+        for row in csv.DictReader(f):
+            pos, pos_rank = _parse_pos(row.get("POS", ""))
+            if not pos:
+                continue
+            # Some rows lack an explicit positional rank; assign by appearance.
+            pos_counters[pos] = pos_counters.get(pos, 0) + 1
+            if pos_rank is None:
+                pos_rank = pos_counters[pos]
+            players.append(
+                Player(
+                    name=row["PLAYER NAME"].strip(),
+                    pos=pos,
+                    pos_rank=pos_rank,
+                    overall_rank=_to_int(row.get("RK"), default=999),
+                    tier=_to_int(row.get("TIERS"), default=99),
+                    bye=_to_int(row.get("BYE WEEK"), default=0),
+                    proj_points=proj_points_from_rank(pos, pos_rank),
+                )
+            )
+    players.sort(key=lambda p: p.overall_rank)
+    return players

--- a/draft/players.py
+++ b/draft/players.py
@@ -12,6 +12,10 @@ from .value import proj_points_from_rank
 
 _POS_RE = re.compile(r"([A-Za-z/]+?)(\d+)?$")
 
+# Canonical position names (league config / ESPN style). FantasyPros says
+# "DST"; everything downstream expects "D/ST".
+_POS_ALIASES = {"DST": "D/ST"}
+
 
 @dataclass
 class Player:
@@ -34,6 +38,7 @@ def _parse_pos(raw: str):
     if not m:
         return raw, None
     pos, rank = m.group(1), m.group(2)
+    pos = _POS_ALIASES.get(pos, pos)
     return pos, (int(rank) if rank else None)
 
 

--- a/draft/scorer.py
+++ b/draft/scorer.py
@@ -17,8 +17,9 @@ _BENCH_MULTIPLIER = 0.45
 _FLEX_MULTIPLIER = 0.9
 
 # Bye-week penalty (in per-game projected points) per conflicting starter.
-_BYE_SAME_POS = 2.0     # heavy: two startable RBs off in the same week hurts
-_BYE_OTHER_POS = 0.5    # mild: general roster-wide bye congestion
+# Public: lineup.py uses the same constants to score final rosters.
+BYE_SAME_POS = 2.0      # heavy: two startable RBs off in the same week hurts
+BYE_OTHER_POS = 0.5     # mild: general roster-wide bye congestion
 
 
 @dataclass
@@ -77,7 +78,7 @@ def bye_penalty(player, roster, config: LeagueConfig) -> float:
     for s in _likely_starters(roster, config):
         if s.bye != player.bye:
             continue
-        penalty += _BYE_SAME_POS if s.pos == player.pos else _BYE_OTHER_POS
+        penalty += BYE_SAME_POS if s.pos == player.pos else BYE_OTHER_POS
     return penalty
 
 

--- a/draft/scorer.py
+++ b/draft/scorer.py
@@ -1,0 +1,129 @@
+"""Phase 1 pick recommender: need-aware VOR with bye penalty and tier context.
+
+score(p | roster) = VOR(p) * need_multiplier(pos, roster) - bye_penalty(p, roster)
+
+Deterministic and fully interpretable. In Phase 2 the need_multiplier heuristic
+is replaced by Monte Carlo lookahead (see docs/DRAFT_MODEL.md).
+"""
+
+from dataclasses import dataclass
+
+from .league import LeagueConfig
+from .value import vor
+
+# Value retained by a player who does NOT fill an open starting slot
+# (bench / injury insurance / handcuff). Elite value still matters, so > 0.
+_BENCH_MULTIPLIER = 0.45
+_FLEX_MULTIPLIER = 0.9
+
+# Bye-week penalty (in per-game projected points) per conflicting starter.
+_BYE_SAME_POS = 2.0     # heavy: two startable RBs off in the same week hurts
+_BYE_OTHER_POS = 0.5    # mild: general roster-wide bye congestion
+
+
+@dataclass
+class Recommendation:
+    player: object
+    score: float
+    base_vor: float
+    need_multiplier: float
+    bye_penalty: float
+    tier_players_left: int
+    reasons: list
+
+
+def _open_starting_needs(roster, config: LeagueConfig) -> dict:
+    """Remaining unfilled starting slots after greedily placing the roster."""
+    needs = dict(config.starters)
+    flex_left = needs.get("FLEX", 0)
+    for p in roster:
+        if needs.get(p.pos, 0) > 0:
+            needs[p.pos] -= 1
+        elif p.pos in config.flex_positions and flex_left > 0:
+            flex_left -= 1
+    if "FLEX" in needs:
+        needs["FLEX"] = flex_left
+    return needs
+
+
+def need_multiplier(pos: str, roster, config: LeagueConfig) -> float:
+    needs = _open_starting_needs(roster, config)
+    if needs.get(pos, 0) > 0:
+        return 1.0
+    if pos in config.flex_positions and needs.get("FLEX", 0) > 0:
+        return _FLEX_MULTIPLIER
+    return _BENCH_MULTIPLIER
+
+
+def _likely_starters(roster, config: LeagueConfig) -> list:
+    """Players who currently occupy a starting slot (for bye-conflict checks)."""
+    needs = dict(config.starters)
+    flex_left = needs.get("FLEX", 0)
+    starters = []
+    for p in roster:
+        if needs.get(p.pos, 0) > 0:
+            needs[p.pos] -= 1
+            starters.append(p)
+        elif p.pos in config.flex_positions and flex_left > 0:
+            flex_left -= 1
+            starters.append(p)
+    return starters
+
+
+def bye_penalty(player, roster, config: LeagueConfig) -> float:
+    if not player.bye:
+        return 0.0
+    penalty = 0.0
+    for s in _likely_starters(roster, config):
+        if s.bye != player.bye:
+            continue
+        penalty += _BYE_SAME_POS if s.pos == player.pos else _BYE_OTHER_POS
+    return penalty
+
+
+def tier_players_left(player, available) -> int:
+    """How many players remain in this player's position AND tier (scarcity)."""
+    return sum(
+        1 for p in available if p.pos == player.pos and p.tier == player.tier
+    )
+
+
+def _build_reasons(rec_pos, mult, byepen, tier_left, base_vor) -> list:
+    reasons = []
+    if mult >= 1.0:
+        reasons.append(f"fills an open {rec_pos} starting slot")
+    elif mult == _FLEX_MULTIPLIER:
+        reasons.append("fills your FLEX")
+    else:
+        reasons.append(f"{rec_pos} starters full — bench/insurance value")
+    if base_vor > 0:
+        reasons.append(f"+{base_vor:.1f} pts/gm over replacement")
+    if tier_left <= 2:
+        reasons.append(f"tier cliff: only {tier_left} left in this tier")
+    if byepen > 0:
+        reasons.append(f"bye stack penalty -{byepen:.1f}")
+    return reasons
+
+
+def recommend(available, roster, config: LeagueConfig, top_k: int = 8) -> list:
+    """Rank available players for the next pick. Returns Recommendations."""
+    recs = []
+    for p in available:
+        base = vor(p.proj_points, p.pos, config)
+        mult = need_multiplier(p.pos, roster, config)
+        byepen = bye_penalty(p, roster, config)
+        score = base * mult - byepen
+        tier_left = tier_players_left(p, available)
+        recs.append(
+            Recommendation(
+                player=p,
+                score=score,
+                base_vor=base,
+                need_multiplier=mult,
+                bye_penalty=byepen,
+                tier_players_left=tier_left,
+                reasons=_build_reasons(p.pos, mult, byepen, tier_left, base),
+            )
+        )
+    recs.sort(key=lambda r: r.score, reverse=True)
+    return recs[:top_k]

--- a/draft/simulate.py
+++ b/draft/simulate.py
@@ -1,0 +1,261 @@
+"""Phase 2: Monte Carlo draft lookahead (docs/DRAFT_MODEL.md).
+
+For each candidate pick, simulate the rest of the snake draft N times —
+opponents sample from ADP with noise, our remaining picks use the fast Phase-1
+greedy policy — and score the final roster with the lineup_value objective.
+Recommend the candidate with the best expected final team.
+
+Everything replans from the live board every pick, so "someone drafted off the
+predicted path" costs nothing: there is no predicted path, only the current
+state.
+
+Design notes:
+- Opponent model: real leagues draft close to ADP. We sample from the top
+  OPP_WINDOW available (after positional-sanity filters) with exponentially
+  decaying weight. Sharpening this with a learned pick-probability model is
+  the designated Phase-3 upgrade and slots in at `opponent_pick`.
+- Our rollout policy is the Phase-1 need-aware VOR score over a small ADP
+  window: cheap, decent, and shared logic with the live recommender.
+- Both policies are forced onto unfilled starting positions when a team's
+  remaining picks run low, so simulated rosters end with legal lineups.
+- Common random numbers: simulation `s` uses the same seed for every
+  candidate, so candidates are compared under paired opponent behavior
+  (variance reduction).
+"""
+
+import random
+from dataclasses import dataclass
+from math import exp, sqrt
+from statistics import fmean, pstdev
+
+from .league import LeagueConfig
+from .lineup import lineup_value
+from .scorer import _open_starting_needs, bye_penalty, need_multiplier, recommend
+from .value import vor
+
+# Opponents consider this many of the best available (post-filter) players...
+OPP_WINDOW = 12
+# ...with weight exp(-i / OPP_TEMP) on the i-th; lower = tighter to ADP.
+OPP_TEMP = 3.0
+# Our rollout policy scores this many of the best available by ADP.
+MY_WINDOW = 20
+# Sanity caps so simulated teams don't hoard onesie positions.
+POSITION_CAPS = {"QB": 2, "TE": 2, "K": 1, "D/ST": 1}
+# K/D:ST become draftable only in a team's last few picks (as humans do).
+LATE_KDST_PICKS = 3
+
+
+def team_for_pick(pick: int, n_teams: int) -> int:
+    """Snake order: 0-based overall pick -> team index."""
+    rnd, slot = divmod(pick, n_teams)
+    return slot if rnd % 2 == 0 else n_teams - 1 - slot
+
+
+@dataclass
+class DraftState:
+    config: LeagueConfig
+    available: list        # Players still on the board, sorted by ADP
+    rosters: list          # list[list[Player]], one per team
+    next_pick: int         # 0-based overall pick number
+    n_rounds: int = 16     # total roster size per team
+
+    @property
+    def total_picks(self) -> int:
+        return self.config.n_teams * self.n_rounds
+
+    @property
+    def done(self) -> bool:
+        return self.next_pick >= self.total_picks
+
+    def clone(self) -> "DraftState":
+        return DraftState(
+            self.config,
+            list(self.available),
+            [list(r) for r in self.rosters],
+            self.next_pick,
+            self.n_rounds,
+        )
+
+    def picks_left(self, team: int) -> int:
+        """How many picks `team` still has, including the current one if on
+        the clock. O(1) via snake structure."""
+        n = self.config.n_teams
+        rnd, pos_in_round = divmod(self.next_pick, n)
+        idx_in_round = team if rnd % 2 == 0 else n - 1 - team
+        still_this_round = 1 if idx_in_round >= pos_in_round else 0
+        return still_this_round + (self.n_rounds - rnd - 1)
+
+    def next_pick_for(self, team: int) -> int:
+        """Overall pick number of `team`'s next turn after the current pick."""
+        for pick in range(self.next_pick + 1, self.total_picks):
+            if team_for_pick(pick, self.config.n_teams) == team:
+                return pick
+        return self.total_picks
+
+
+def _eligible_indices(state: DraftState, team: int, window: int) -> list:
+    """Indices (into state.available) a team would realistically consider.
+
+    Applies: forced-need mode when remaining picks barely cover unfilled
+    starting slots; positional caps; and no K/D:ST until the late rounds.
+    """
+    roster = state.rosters[team]
+    config = state.config
+    picks_left = state.picks_left(team)
+    needs = _open_starting_needs(roster, config)
+    must = sum(needs.values())
+    force = picks_left <= must
+
+    counts = {}
+    for p in roster:
+        counts[p.pos] = counts.get(p.pos, 0) + 1
+
+    out = []
+    for i, p in enumerate(state.available):
+        if force:
+            ok = needs.get(p.pos, 0) > 0 or (
+                needs.get("FLEX", 0) > 0 and p.pos in config.flex_positions
+            )
+            if not ok:
+                continue
+        else:
+            if counts.get(p.pos, 0) >= POSITION_CAPS.get(p.pos, 99):
+                continue
+            if p.pos in ("K", "D/ST") and picks_left > LATE_KDST_PICKS:
+                continue
+        out.append(i)
+        if len(out) >= window:
+            break
+    # Degenerate board (filters excluded everything): take best available.
+    return out or list(range(min(window, len(state.available))))
+
+
+def opponent_pick(state: DraftState, team: int, rng: random.Random) -> int:
+    """ADP-with-noise opponent model. Returns an index into state.available."""
+    idxs = _eligible_indices(state, team, OPP_WINDOW)
+    weights = [exp(-j / OPP_TEMP) for j in range(len(idxs))]
+    return rng.choices(idxs, weights=weights, k=1)[0]
+
+
+def my_rollout_pick(state: DraftState, team: int,
+                    exclude_name: str = None) -> int:
+    """Our fast in-simulation policy: Phase-1 greedy score over an ADP window.
+
+    `exclude_name` supports the survival question "what do I take if I pass
+    on this player?" — the excluded player stays on the board.
+    """
+    roster = state.rosters[team]
+    config = state.config
+    best_i, best_score = None, float("-inf")
+    for i in _eligible_indices(state, team, MY_WINDOW):
+        p = state.available[i]
+        if exclude_name is not None and p.name == exclude_name:
+            continue
+        score = (
+            vor(p.proj_points, p.pos, config)
+            * need_multiplier(p.pos, roster, config)
+            - bye_penalty(p, roster, config)
+        )
+        if score > best_score:
+            best_i, best_score = i, score
+    if best_i is None:  # window contained only the excluded player
+        best_i = next(
+            i for i, p in enumerate(state.available) if p.name != exclude_name
+        )
+    return best_i
+
+
+def play_out(state: DraftState, my_team: int, rng: random.Random,
+             stop_at_pick: int = None) -> DraftState:
+    """Advance the draft in place until completion (or `stop_at_pick`)."""
+    stop = state.total_picks if stop_at_pick is None else min(
+        stop_at_pick, state.total_picks
+    )
+    while state.next_pick < stop and state.available:
+        team = team_for_pick(state.next_pick, state.config.n_teams)
+        if team == my_team:
+            idx = my_rollout_pick(state, team)
+        else:
+            idx = opponent_pick(state, team, rng)
+        state.rosters[team].append(state.available.pop(idx))
+        state.next_pick += 1
+    return state
+
+
+@dataclass
+class CandidateEval:
+    player: object
+    mean_value: float     # E[final TeamValue | take this player now]
+    std_err: float
+    survival_pct: float   # P(still available at my next pick if I pass now)
+
+
+def _candidates(state: DraftState, my_team: int, top_k: int,
+                extra_adp: int) -> list:
+    """Greedy shortlist plus the very top of the ADP board (coverage)."""
+    recs = recommend(state.available, state.rosters[my_team], state.config,
+                     top_k=top_k)
+    cands = [r.player for r in recs]
+    names = {p.name for p in cands}
+    for p in state.available[:extra_adp]:
+        if p.name not in names:
+            cands.append(p)
+            names.add(p.name)
+    return cands
+
+
+def _survival(state: DraftState, my_team: int, cands: list, n_sims: int,
+              seed: int) -> dict:
+    """P(candidate survives to my next pick) given I pass on him now.
+
+    Per candidate: my current pick becomes my greedy choice *excluding* the
+    candidate, opponents draft to my next turn, and we check whether the
+    candidate is still on the board.
+    """
+    next_mine = state.next_pick_for(my_team)
+    out = {}
+    for cand in cands:
+        survived = 0
+        for s in range(n_sims):
+            rng = random.Random((seed + 7919) * 100003 + s)
+            sim = state.clone()
+            idx = my_rollout_pick(sim, my_team, exclude_name=cand.name)
+            sim.rosters[my_team].append(sim.available.pop(idx))
+            sim.next_pick += 1
+            play_out(sim, my_team, rng, stop_at_pick=next_mine)
+            if any(p.name == cand.name for p in sim.available):
+                survived += 1
+        out[cand.name] = 100.0 * survived / n_sims
+    return out
+
+
+def mc_recommend(state: DraftState, my_team: int, n_sims: int = 100,
+                 seed: int = 0, top_k: int = 8, extra_adp: int = 3) -> list:
+    """Monte Carlo lookahead. Returns CandidateEvals sorted best-first."""
+    cands = _candidates(state, my_team, top_k, extra_adp)
+    survival = _survival(state, my_team, cands, max(n_sims, 100), seed)
+
+    results = []
+    for cand in cands:
+        values = []
+        for s in range(n_sims):
+            # Same seed across candidates for paired comparison.
+            rng = random.Random(seed * 100003 + s)
+            sim = state.clone()
+            idx = next(
+                i for i, p in enumerate(sim.available) if p.name == cand.name
+            )
+            sim.rosters[my_team].append(sim.available.pop(idx))
+            sim.next_pick += 1
+            play_out(sim, my_team, rng)
+            values.append(lineup_value(sim.rosters[my_team], sim.config))
+        results.append(
+            CandidateEval(
+                player=cand,
+                mean_value=fmean(values),
+                std_err=pstdev(values) / sqrt(len(values)),
+                survival_pct=survival[cand.name],
+            )
+        )
+    results.sort(key=lambda r: r.mean_value, reverse=True)
+    return results

--- a/draft/value.py
+++ b/draft/value.py
@@ -1,0 +1,40 @@
+"""Player value: projected points and Value Over Replacement (VOR).
+
+Projected points are the ONE input we don't have offline. In the real pipeline
+they come from ESPN's `kona_player_info` view. Here we derive a transparent
+proxy from positional rank so the prototype runs on real player/bye data today.
+
+To go live: replace `proj_points_from_rank` with real projections and every
+downstream number (VOR, need-adjusted score) becomes real. Nothing else changes.
+"""
+
+from .league import LeagueConfig
+
+# Per-game PPR anchors: (points for pos_rank 1, per-rank decline, floor).
+# Calibrated to rough real-world shapes so cross-position VOR is sane
+# (elite RB/WR > elite QB in VOR because QB replacement level is high).
+PROJECTION_ANCHORS = {
+    "QB":   (24.0, 0.45, 14.0),
+    "RB":   (21.0, 0.42, 6.0),
+    "WR":   (20.0, 0.34, 6.0),
+    "TE":   (15.0, 0.55, 4.0),
+    "D/ST": (8.0,  0.15, 4.0),
+    "K":    (9.0,  0.10, 6.0),
+}
+_DEFAULT_ANCHOR = (10.0, 0.30, 3.0)
+
+
+def proj_points_from_rank(pos: str, pos_rank: int) -> float:
+    """PROXY projection (per game) from positional rank. Replace with real data."""
+    top, slope, floor = PROJECTION_ANCHORS.get(pos, _DEFAULT_ANCHOR)
+    return max(floor, top - slope * (pos_rank - 1))
+
+
+def replacement_points(pos: str, config: LeagueConfig) -> float:
+    """Projection of the last startable player at `pos` (the VOR baseline)."""
+    return proj_points_from_rank(pos, config.replacement_rank(pos))
+
+
+def vor(proj_points: float, pos: str, config: LeagueConfig) -> float:
+    """Value Over Replacement: points above a freely-available starter."""
+    return proj_points - replacement_points(pos, config)

--- a/spike/README.md
+++ b/spike/README.md
@@ -1,0 +1,57 @@
+# ESPN JSON API Spike
+
+Proves we can read your league — settings, rosters, player pool, and draft
+picks — straight from ESPN's internal JSON API. No Selenium, no XPath, no
+copy/paste. This replaces the entire brittle scraping layer from the original
+notebook.
+
+## Why a completed season?
+
+It's the off-season, so there's no live draft to poll. A **completed** draft
+returns the same `mDraftDetail` shape a live one does, so running this against
+last year validates auth, endpoints, and parsing today. The only thing it
+can't exercise until draft night is real-time polling cadence.
+
+## Setup
+
+```bash
+pip install requests python-dotenv
+cp .env.example .env      # then edit .env
+python spike/espn_api_spike.py
+```
+
+## Finding your LEAGUE_ID
+
+Open your league on fantasy.espn.com. The URL contains it:
+
+```
+https://fantasy.espn.com/football/league?leagueId=123456
+                                                  ^^^^^^  <- this
+```
+
+## Getting the cookies (private leagues only)
+
+If your league is private you need two auth cookies. **These are sensitive —
+treat them like a password.** They let anyone read (and potentially act in)
+your league. Notes on where to run this are below.
+
+1. Log into https://fantasy.espn.com in Chrome/Firefox.
+2. Open DevTools (F12) → **Application** (Chrome) or **Storage** (Firefox) →
+   **Cookies** → `https://fantasy.espn.com`.
+3. Copy the **`espn_s2`** value (a long URL-encoded string) into `ESPN_S2`.
+4. Copy the **`SWID`** value (a GUID in `{...}` braces — keep the braces) into
+   `SWID`.
+
+## A note on where to run this
+
+`.env` is gitignored so your cookies won't be committed. But this repo can run
+in a cloud container — if you'd rather not place real ESPN cookies in a shared
+remote environment, run this spike **locally** on your own machine instead.
+For a **public** league no cookies are needed at all, which is the safest way
+to smoke-test the endpoints.
+
+## What success looks like
+
+You should see your league name, a list of draft picks with real player names,
+and sample rosters. If so, the JSON-API approach is validated and we can build
+the real "press go" assistant on top of it.

--- a/spike/espn_api_spike.py
+++ b/spike/espn_api_spike.py
@@ -1,0 +1,177 @@
+"""
+ESPN Fantasy Football — undocumented JSON API spike.
+
+Goal: prove we can read a league's settings, rosters, the player pool, and
+draft picks straight from ESPN's internal JSON API — no Selenium, no XPath.
+
+It's the off-season, so there is no *live* draft to poll. That's fine: a
+completed prior-season draft returns the same `mDraftDetail` shape a live one
+does, so running this against last year validates auth + endpoints + parsing.
+The only thing it can't exercise until draft night is the polling cadence.
+
+Usage:
+    1. Copy .env.example -> .env and fill in the values (see spike/README.md
+       for how to grab the cookies from your browser).
+    2. pip install requests python-dotenv
+    3. python spike/espn_api_spike.py
+
+Public leagues need only LEAGUE_ID + SEASON. Private leagues also need the
+ESPN_S2 and SWID cookies.
+"""
+
+import json
+import os
+import sys
+
+import requests
+
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv()
+except ImportError:
+    pass  # .env is optional; env vars may be set another way.
+
+
+BASE = "https://lm-api-reads.fantasy.espn.com/apis/v3/games/ffl"
+
+
+def get_config():
+    league_id = os.environ.get("LEAGUE_ID")
+    season = os.environ.get("SEASON")
+    if not league_id or not season:
+        sys.exit(
+            "Missing config. Set LEAGUE_ID and SEASON (in a .env file or env "
+            "vars). See spike/README.md."
+        )
+    cookies = {}
+    espn_s2 = os.environ.get("ESPN_S2")
+    swid = os.environ.get("SWID")
+    if espn_s2 and swid:
+        cookies = {"espn_s2": espn_s2, "SWID": swid}
+    return league_id, season, cookies
+
+
+def fetch(league_id, season, cookies, views, extra_headers=None):
+    """Hit the league endpoint with one or more `view` params."""
+    url = f"{BASE}/seasons/{season}/segments/0/leagues/{league_id}"
+    params = [("view", v) for v in views]
+    headers = {"User-Agent": "Mozilla/5.0"}
+    if extra_headers:
+        headers.update(extra_headers)
+    resp = requests.get(url, params=params, cookies=cookies, headers=headers, timeout=20)
+    if resp.status_code == 401:
+        sys.exit(
+            "401 Unauthorized — this looks like a private league. Set ESPN_S2 "
+            "and SWID cookies in .env. See spike/README.md."
+        )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def build_player_map(league_id, season, cookies, limit=400):
+    """id -> name map from the draftable player pool (kona_player_info)."""
+    filt = {
+        "players": {
+            "limit": limit,
+            "sortDraftRanks": {
+                "sortPriority": 100,
+                "sortAsc": True,
+                "value": "STANDARD",
+            },
+        }
+    }
+    try:
+        data = fetch(
+            league_id,
+            season,
+            cookies,
+            ["kona_player_info"],
+            extra_headers={"x-fantasy-filter": json.dumps(filt)},
+        )
+    except requests.HTTPError as exc:
+        print(f"  (couldn't load player pool: {exc}; picks will show IDs only)")
+        return {}
+    players = data.get("players", [])
+    return {p["id"]: p.get("player", {}).get("fullName", f"#{p['id']}") for p in players}
+
+
+def show_settings(data):
+    settings = data.get("settings", {})
+    print("=" * 60)
+    print(f"League:   {settings.get('name', '(unknown)')}")
+    size = settings.get("size")
+    if size:
+        print(f"Teams:    {size}")
+    scoring = settings.get("scoringSettings", {})
+    scoring_type = scoring.get("scoringType")
+    if scoring_type:
+        print(f"Scoring:  {scoring_type}")
+    roster = settings.get("rosterSettings", {})
+    slots = roster.get("lineupSlotCounts")
+    if slots:
+        # Only print the non-zero slots; slot ids map to positions.
+        active = {k: v for k, v in slots.items() if v}
+        print(f"Roster slots (slotId:count): {active}")
+    print("=" * 60)
+
+
+def show_draft(data, player_map, max_picks=20):
+    detail = data.get("draftDetail", {})
+    picks = detail.get("picks", [])
+    print(f"\nDraft: drafted={detail.get('drafted')}, inProgress="
+          f"{detail.get('inProgress')}, picks={len(picks)}")
+    if not picks:
+        print("  (no picks yet — expected in the off-season before draft night)")
+        return
+    print(f"  Showing first {min(max_picks, len(picks))} picks:")
+    for pick in picks[:max_picks]:
+        pid = pick.get("playerId")
+        name = player_map.get(pid, f"#{pid}")
+        print(
+            f"    R{pick.get('roundId'):>2} "
+            f"P{pick.get('roundPickNumber'):>2} "
+            f"(overall {pick.get('overallPickNumber'):>3}) "
+            f"team {pick.get('teamId'):>2} -> {name}"
+        )
+
+
+def show_teams(data, player_map, max_teams=3):
+    teams = data.get("teams", [])
+    print(f"\nTeams: {len(teams)} found. Sample rosters:")
+    for team in teams[:max_teams]:
+        name = team.get("name") or f"Team {team.get('id')}"
+        entries = team.get("roster", {}).get("entries", [])
+        players = [
+            player_map.get(
+                e.get("playerId"),
+                e.get("playerPoolEntry", {}).get("player", {}).get("fullName", "?"),
+            )
+            for e in entries
+        ]
+        print(f"  {name}: {len(players)} players")
+        if players:
+            print(f"    {', '.join(players[:8])}{' ...' if len(players) > 8 else ''}")
+
+
+def main():
+    league_id, season, cookies = get_config()
+    mode = "PRIVATE (cookie auth)" if cookies else "PUBLIC (no auth)"
+    print(f"Querying league {league_id}, season {season} — {mode}\n")
+
+    print("Building player id->name map from the draftable pool...")
+    player_map = build_player_map(league_id, season, cookies)
+    print(f"  loaded {len(player_map)} players\n")
+
+    data = fetch(
+        league_id, season, cookies, ["mSettings", "mDraftDetail", "mTeam", "mRoster"]
+    )
+    show_settings(data)
+    show_draft(data, player_map)
+    show_teams(data, player_map)
+    print("\nSpike complete. If you see a league name, draft picks with real "
+          "player names, and rosters above, the JSON-API approach is validated.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Implements the core decision engine for the fantasy football draft assistant, spanning Phase 1 (need-aware VOR scoring) and Phase 2 (Monte Carlo lookahead simulation). Includes player data loading, league configuration, lineup valuation, and an ESPN JSON API spike for live league integration.

## Key Changes

**Core Recommendation Engine:**
- `draft/scorer.py`: Phase 1 greedy recommender using Value Over Replacement (VOR) adjusted for positional need and bye-week conflicts
- `draft/simulate.py`: Phase 2 Monte Carlo lookahead that simulates rest-of-draft scenarios with ADP-based opponent model and fast rollout policy
- `draft/lineup.py`: Objective function (TeamValue) that scores final rosters by best-achievable starting-lineup points minus bye congestion

**Player & League Data:**
- `draft/players.py`: Load FantasyPros CSV rankings into Player objects with position, tier, bye week, and rank-derived projected points
- `draft/league.py`: LeagueConfig dataclass for roster construction (starters, flex eligibility, team count)
- `draft/value.py`: VOR calculation and replacement-level baselines; projected points proxy (to be replaced by live ESPN data)

**Demos & Validation:**
- `draft/demo.py`: Phase 1 recommender on simulated mid-draft state with real player data
- `draft/demo_mc.py`: Side-by-side Phase 1 vs Phase 2 comparison, including survival probabilities
- `spike/espn_api_spike.py`: Proof-of-concept ESPN JSON API client (settings, rosters, draft picks, player pool)
- `spike/README.md`: Setup guide for ESPN integration (public/private league auth)

**Configuration:**
- `.env.example`: Template for ESPN league credentials

## Notable Implementation Details

- **Snake draft order**: `team_for_pick()` correctly handles round parity for snake-order pick assignment
- **Opponent model**: Exponentially-weighted sampling from top-N available players (ADP with noise) — cheap, realistic, and the designated Phase-3 upgrade point
- **Forced-need mode**: When picks remaining ≈ unfilled starting slots, both opponent and rollout policies are constrained to fill positions, ensuring legal final rosters
- **Common random numbers**: Each simulation seed is paired across all candidates for variance reduction in comparisons
- **Survival analysis**: Computes P(candidate still available at my next pick | I pass now) by simulating opponents' picks
- **Objective alignment**: Bye penalties, positional scarcity, and roster balance all emerge from maximizing final TeamValue — no hand-coded rules

The design separates player value (projections) from pick strategy (sequential, adversarial optimization), enabling the simulator to be swapped with learned policies later without changing the objective.

https://claude.ai/code/session_01Lxuw7UBWfNEBSSWnhicaY6